### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/.workflows/go.yml
+++ b/.github/.workflows/go.yml
@@ -1,0 +1,35 @@
+name: Go
+
+on: [push, pull_request]
+
+jobs:
+
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go: ['1.19', '1.20','1.21']
+      fail-fast: false
+    env:
+      OS: ${{ matrix.os }}
+      GO: ${{ matrix.go }}
+      steps:  
+        - uses: actions/setup-go@v2
+          with:
+            go-version: ${{ matrix.go }}
+  
+        - name: Go Build
+          run: |
+            go build cmd/dfence.go
+
+        - name: Go Tests
+          run: |
+            go test ./...       
+
+

--- a/.github/.workflows/go.yml
+++ b/.github/.workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: ['1.19', '1.20','1.21']
+        go: ['1.15','1.21']
       fail-fast: false
     env:
       OS: ${{ matrix.os }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/" 
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
We need to ensure that the project can be build on : 
- Windows
- Mac OS X
- Linux (Ubuntu)

We need also to ensure that the smallest version (inside the Go.mod) is supported and that the latest go version is also supported. 
We could add all versions in the middle but that would lead to very high CPU intensive computational power not very required here. 